### PR TITLE
[Tool bar] Implement a mechanism for specific flavor behaviour for the activity tool bars

### DIFF
--- a/CameraColorPicker/app/src/adult/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorDetailActivityFlavor.java
+++ b/CameraColorPicker/app/src/adult/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorDetailActivityFlavor.java
@@ -1,0 +1,37 @@
+package fr.tvbarthel.apps.cameracolorpicker.activities;
+
+import android.os.Bundle;
+import android.view.Menu;
+
+/**
+ * Static methods for specific flavor behaviour of {@link ColorDetailActivity}.
+ */
+/* package */
+final class ColorDetailActivityFlavor {
+
+    /**
+     * Called when {@link ColorDetailActivity#onCreate(Bundle)} is called.
+     * <p/>
+     * <b>Note</b> this should be the last methods called in {@link ColorDetailActivity#onCreate(Bundle)}.
+     *
+     * @param activity the {@link ColorDetailActivity}.
+     */
+    /* package */
+    static void onCreate(ColorDetailActivity activity) {
+        // nothing specific for the adult flavor.
+    }
+
+    /**
+     * Called when {@link ColorDetailActivity#onCreateOptionsMenu(Menu)} is called.
+     *
+     * @param menu the {@link Menu} created.
+     */
+    /* package */
+    static void onCreateOptionsMenu(Menu menu) {
+        // nothing specific for the adult flavor.
+    }
+
+    private ColorDetailActivityFlavor() {
+        // non-instantiable.
+    }
+}

--- a/CameraColorPicker/app/src/adult/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorPickerActivityFlavor.java
+++ b/CameraColorPicker/app/src/adult/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorPickerActivityFlavor.java
@@ -1,0 +1,26 @@
+package fr.tvbarthel.apps.cameracolorpicker.activities;
+
+import android.os.Bundle;
+
+/**
+ * Static methods for specific flavor behaviour of {@link ColorPickerActivity}.
+ */
+/* package */
+final class ColorPickerActivityFlavor {
+
+    /**
+     * Called when {@link ColorPickerActivity#onCreate(Bundle)} is called.
+     * <p/>
+     * <b>Note</b> this should be the last methods called in {@link ColorPickerActivity#onCreate(Bundle)}.
+     *
+     * @param activity the {@link ColorDetailActivity}.
+     */
+    /* package */
+    static void onCreate(ColorPickerActivity activity) {
+        // nothing specific for the adult flavor.
+    }
+
+    private ColorPickerActivityFlavor() {
+        // non-instantiable
+    }
+}

--- a/CameraColorPicker/app/src/adult/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteCreationActivityFlavor.java
+++ b/CameraColorPicker/app/src/adult/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteCreationActivityFlavor.java
@@ -1,0 +1,22 @@
+package fr.tvbarthel.apps.cameracolorpicker.activities;
+
+import android.os.Bundle;
+
+/**
+ * Static methods for specific flavor behaviour of {@link PaletteCreationActivity}.
+ */
+/* package */
+final class PaletteCreationActivityFlavor {
+
+    /**
+     * Called when {@link PaletteCreationActivity#onCreate(Bundle)} is called.
+     * <p/>
+     * <b>Note</b> this should be the last methods called in {@link PaletteCreationActivity#onCreate(Bundle)}.
+     *
+     * @param activity the {@link PaletteCreationActivity}.
+     */
+    /* package */
+    static void onCreate(PaletteCreationActivity activity) {
+        // nothing specific for the adult flavor.
+    }
+}

--- a/CameraColorPicker/app/src/adult/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteDetailActivityFlavor.java
+++ b/CameraColorPicker/app/src/adult/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteDetailActivityFlavor.java
@@ -1,0 +1,40 @@
+package fr.tvbarthel.apps.cameracolorpicker.activities;
+
+import android.os.Bundle;
+import android.view.Menu;
+
+/**
+ * Static methods for specific flavor behaviour of {@link PaletteDetailActivity}.
+ */
+/* package */
+final class PaletteDetailActivityFlavor {
+
+
+    /**
+     * Called when {@link PaletteDetailActivity#onCreate(Bundle)} is called.
+     * <p/>
+     * <b>Note</b> this should be the last methods called in {@link PaletteDetailActivity#onCreate(Bundle)}.
+     *
+     * @param activity the {@link PaletteDetailActivity}.
+     */
+    /* package */
+    static void onCreate(PaletteDetailActivity activity) {
+        // nothing specific for the adult flavor.
+    }
+
+    /**
+     * Called when {@link PaletteDetailActivity#onCreateOptionsMenu(Menu)} is called.
+     *
+     * @param menu the {@link Menu} created.
+     */
+    /* package */
+    static void onCreateOptionsMenu(Menu menu) {
+        // nothing specific for the adult flavor.
+    }
+
+
+    private PaletteDetailActivityFlavor() {
+        // non-instantiable.
+    }
+
+}

--- a/CameraColorPicker/app/src/kids/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorDetailActivityFlavor.java
+++ b/CameraColorPicker/app/src/kids/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorDetailActivityFlavor.java
@@ -1,0 +1,43 @@
+package fr.tvbarthel.apps.cameracolorpicker.activities;
+
+import android.os.Bundle;
+import android.view.Menu;
+
+import fr.tvbarthel.apps.cameracolorpicker.R;
+
+/**
+ * Static methods for specific flavor behaviour of {@link ColorDetailActivity}.
+ */
+/* package */
+final class ColorDetailActivityFlavor {
+
+    /**
+     * Called when {@link ColorDetailActivity#onCreate(Bundle)} is called.
+     * <p/>
+     * <b>Note</b> this should be the last methods called in {@link ColorDetailActivity#onCreate(Bundle)}.
+     *
+     * @param activity the {@link ColorDetailActivity}.
+     */
+    /* package */
+    static void onCreate(ColorDetailActivity activity) {
+        // For the kid version, set the title to null.
+        //noinspection ConstantConditions
+        activity.getSupportActionBar().setTitle(null);
+    }
+
+    /**
+     * Called when {@link ColorDetailActivity#onCreateOptionsMenu(Menu)} is called.
+     *
+     * @param menu the {@link Menu} created.
+     */
+    /* package */
+    static void onCreateOptionsMenu(Menu menu) {
+        // For the kid version, hide the edit and share menu items.
+        menu.removeItem(R.id.menu_color_detail_action_edit);
+        menu.removeItem(R.id.menu_color_detail_action_share);
+    }
+
+    private ColorDetailActivityFlavor() {
+        // non-instantiable.
+    }
+}

--- a/CameraColorPicker/app/src/kids/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorPickerActivityFlavor.java
+++ b/CameraColorPicker/app/src/kids/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorPickerActivityFlavor.java
@@ -1,0 +1,28 @@
+package fr.tvbarthel.apps.cameracolorpicker.activities;
+
+import android.os.Bundle;
+
+/**
+ * Static methods for specific flavor behaviour of {@link ColorPickerActivity}.
+ */
+/* package */
+final class ColorPickerActivityFlavor {
+
+    /**
+     * Called when {@link ColorPickerActivity#onCreate(Bundle)} is called.
+     * <p/>
+     * <b>Note</b> this should be the last methods called in {@link ColorPickerActivity#onCreate(Bundle)}.
+     *
+     * @param activity the {@link ColorDetailActivity}.
+     */
+    /* package */
+    static void onCreate(ColorPickerActivity activity) {
+        // For the kid version, set the title to null.
+        //noinspection ConstantConditions
+        activity.getSupportActionBar().setTitle(null);
+    }
+
+    private ColorPickerActivityFlavor() {
+        // non-instantiable
+    }
+}

--- a/CameraColorPicker/app/src/kids/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteCreationActivityFlavor.java
+++ b/CameraColorPicker/app/src/kids/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteCreationActivityFlavor.java
@@ -1,0 +1,24 @@
+package fr.tvbarthel.apps.cameracolorpicker.activities;
+
+import android.os.Bundle;
+
+/**
+ * Static methods for specific flavor behaviour of {@link PaletteCreationActivity}.
+ */
+/* package */
+final class PaletteCreationActivityFlavor {
+
+    /**
+     * Called when {@link PaletteCreationActivity#onCreate(Bundle)} is called.
+     * <p/>
+     * <b>Note</b> this should be the last methods called in {@link PaletteCreationActivity#onCreate(Bundle)}.
+     *
+     * @param activity the {@link PaletteCreationActivity}.
+     */
+    /* package */
+    static void onCreate(PaletteCreationActivity activity) {
+        // For the kid version, set the title to null.
+        //noinspection ConstantConditions
+        activity.getSupportActionBar().setTitle(null);
+    }
+}

--- a/CameraColorPicker/app/src/kids/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteDetailActivityFlavor.java
+++ b/CameraColorPicker/app/src/kids/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteDetailActivityFlavor.java
@@ -1,0 +1,47 @@
+package fr.tvbarthel.apps.cameracolorpicker.activities;
+
+import android.os.Bundle;
+import android.support.v7.app.ActionBar;
+import android.view.Menu;
+
+import fr.tvbarthel.apps.cameracolorpicker.R;
+
+/**
+ * Static methods for specific flavor behaviour of {@link PaletteDetailActivity}.
+ */
+/* package */
+final class PaletteDetailActivityFlavor {
+
+
+    /**
+     * Called when {@link PaletteDetailActivity#onCreate(Bundle)} is called.
+     * <p/>
+     * <b>Note</b> this should be the last methods called in {@link PaletteDetailActivity#onCreate(Bundle)}.
+     *
+     * @param activity the {@link PaletteDetailActivity}.
+     */
+    /* package */
+    static void onCreate(PaletteDetailActivity activity) {
+        // For the kid version, set the title to null.
+        //noinspection ConstantConditions
+        activity.getSupportActionBar().setTitle(null);
+    }
+
+    /**
+     * Called when {@link PaletteDetailActivity#onCreateOptionsMenu(Menu)} is called.
+     *
+     * @param menu the {@link Menu} created.
+     */
+    /* package */
+    static void onCreateOptionsMenu(Menu menu) {
+        // For the kid version, hide the edit and share menu items.
+        menu.removeItem(R.id.menu_palette_detail_action_edit);
+        menu.removeItem(R.id.menu_palette_detail_action_share);
+    }
+
+
+    private PaletteDetailActivityFlavor() {
+        // non-instantiable.
+    }
+
+}

--- a/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorDetailActivity.java
+++ b/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorDetailActivity.java
@@ -257,6 +257,8 @@ public class ColorDetailActivity extends AppCompatActivity implements View.OnCli
                 }
             });
         }
+
+        ColorDetailActivityFlavor.onCreate(this);
     }
 
     @Override
@@ -280,6 +282,7 @@ public class ColorDetailActivity extends AppCompatActivity implements View.OnCli
             // A color associated with a palette can't be deleted.
             menu.removeItem(R.id.menu_color_detail_action_delete);
         }
+        ColorDetailActivityFlavor.onCreateOptionsMenu(menu);
         return true;
     }
 

--- a/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorPickerActivity.java
+++ b/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/ColorPickerActivity.java
@@ -210,6 +210,8 @@ public class ColorPickerActivity extends AppCompatActivity implements CameraColo
         initSaveCompletedProgressAnimator();
         initViews();
         initTranslationDeltas();
+
+        ColorPickerActivityFlavor.onCreate(this);
     }
 
     @Override

--- a/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteCreationActivity.java
+++ b/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteCreationActivity.java
@@ -57,6 +57,7 @@ public class PaletteCreationActivity extends AppCompatActivity implements OnClic
         mRemoveLastColorBtnAnimator = ObjectAnimator.ofFloat(removeButton, View.SCALE_X, 0f, 1f);
 
         findViewById(R.id.activity_palette_creation_fab).setOnClickListener(this);
+        PaletteCreationActivityFlavor.onCreate(this);
     }
 
     @Override

--- a/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteDetailActivity.java
+++ b/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/PaletteDetailActivity.java
@@ -36,9 +36,9 @@ import fr.tvbarthel.apps.cameracolorpicker.data.Palette;
 import fr.tvbarthel.apps.cameracolorpicker.data.Palettes;
 import fr.tvbarthel.apps.cameracolorpicker.fragments.DeletePaletteDialogFragment;
 import fr.tvbarthel.apps.cameracolorpicker.fragments.EditTextDialogFragment;
-import fr.tvbarthel.apps.cameracolorpicker.wrappers.ColorItemListWrapper;
 import fr.tvbarthel.apps.cameracolorpicker.views.FlavorColorItemListWrapper;
 import fr.tvbarthel.apps.cameracolorpicker.views.PaletteView;
+import fr.tvbarthel.apps.cameracolorpicker.wrappers.ColorItemListWrapper;
 
 /**
  * A simple {@link AppCompatActivity} for displaying a {@link Palette} with its {@link ColorItem}s
@@ -244,6 +244,8 @@ public class PaletteDetailActivity extends AppCompatActivity implements DeletePa
         };
 
         Palettes.registerListener(this, mOnPaletteChangeListener);
+
+        PaletteDetailActivityFlavor.onCreate(this);
     }
 
     @Override
@@ -268,6 +270,7 @@ public class PaletteDetailActivity extends AppCompatActivity implements DeletePa
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.menu_palette_detail, menu);
+        PaletteDetailActivityFlavor.onCreateOptionsMenu(menu);
         return true;
     }
 


### PR DESCRIPTION
The xxxActivityFlavor are hooked to the activity methods to change the title or the menu.

For the kid version, the activity (except the MainActivity) have no titles.
For the kid version, the ColorDetailActivity and the PaletteDetailActivity no longer display a share action nor an edit action.
