### PR TITLE
[Palette] emphase on the right actions, fix #23

### DIFF
--- a/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/MainActivity.java
+++ b/CameraColorPicker/app/src/main/java/fr/tvbarthel/apps/cameracolorpicker/activities/MainActivity.java
@@ -270,8 +270,14 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     @Override
     public void onEmphasisOnPaletteCreationRequested() {
-        mViewPager.setCurrentItem(0, true);
-        animateFab(mFab, 300);
+        if (ColorItems.getSavedColorItems(this).size() <= 1) {
+            // needs more color to create a palette.
+            mViewPager.setCurrentItem(0, true);
+            animateFab(mFab, 300);
+        } else {
+            // touch the fab to create a palette.
+            animateFab(mFab, 0);
+        }
     }
 
     /**


### PR DESCRIPTION
When already 2 colors or more, palette creation action must be
highlighted instead of color picking.
